### PR TITLE
Implement component_find

### DIFF
--- a/ecs.c
+++ b/ecs.c
@@ -164,6 +164,11 @@ static void component_remove_branch(struct component *c, struct branch *branch) 
     free(branch);
 }
 
+void* component_find(struct component const *c, int i) {
+    struct branch *b = branch_find(c->root, i);
+    return b ? branch_ptr(b, c->size, i) : NULL;
+}
+
 void* component_data(struct component *c, int i) {
     struct branch *b = branch_find(c->root, i);
     if (b) {

--- a/ecs.h
+++ b/ecs.h
@@ -8,5 +8,6 @@ struct component {
 };
 
 void* component_data(struct component*, int i);
+void* component_find(struct component const*, int i);
 void  component_drop(struct component*, int i);
 void  component_each(struct component*, void (*fn)(int i, void *data, void *ctx), void *ctx);

--- a/ecs_test.c
+++ b/ecs_test.c
@@ -23,6 +23,14 @@ int main(void) {
         *val = i * 10;
     }
 
+    expect(component_find(&c, 0) == NULL);
+    for (int i = 1; i <= 5; ++i) {
+        int *val = component_find(&c, i);
+        expect(val != NULL);
+        expect(*val == i * 10);
+    }
+    expect(component_find(&c, 6) == NULL);
+
     {
         int *val = component_data(&c, 3);
         expect(*val == 30);
@@ -35,6 +43,7 @@ int main(void) {
     }
 
     component_drop(&c, 3);
+    expect(component_find(&c, 3) == NULL);
     {
         int sum = 0;
         component_each(&c, sum_fn, &sum);
@@ -53,6 +62,12 @@ int main(void) {
         expect(p != NULL);
     }
 
+    expect(component_find(&tag, 0) == NULL);
+    for (int i = 1; i <= 5; ++i) {
+        expect(component_find(&tag, i) != NULL);
+    }
+    expect(component_find(&tag, 6) == NULL);
+
     {
         int count = 0;
         component_each(&tag, count_fn, &count);
@@ -60,6 +75,7 @@ int main(void) {
     }
 
     component_drop(&tag, 3);
+    expect(component_find(&tag, 3) == NULL);
     {
         int count = 0;
         component_each(&tag, count_fn, &count);
@@ -70,6 +86,7 @@ int main(void) {
         component_drop(&tag, i);
     }
     expect(tag.root == NULL);
+    expect(component_find(&tag, 1) == NULL);
 
     return 0;
 }


### PR DESCRIPTION
## Summary
- add `component_find()` for lookups without allocation
- cover the new function in tests

## Testing
- `ninja -v out/ecs_test.ok`

------
https://chatgpt.com/codex/tasks/task_e_686a3e24526c8326a210666983846398