### PR TITLE
Enable coverage and expand tests

### DIFF
--- a/build.ninja
+++ b/build.ninja
@@ -1,6 +1,6 @@
 builddir = out
 
-cc   = clang -fsanitize=address,integer,undefined
+cc   = clang -fsanitize=address,integer,undefined -fprofile-instr-generate -fcoverage-mapping
 warn = -Weverything $
        -Wno-declaration-after-statement $
        -Wno-poison-system-directories $
@@ -13,10 +13,10 @@ rule compile
     deps    = gcc
 
 rule link
-    command = $cc $in -o $out
+    command = $cc $in -o $out -fprofile-instr-generate
 
 rule run
-    command = ./$in > $out
+    command = LLVM_PROFILE_FILE=$in.profraw ./$in > $out
 
 build out/ecs.o:       compile  ecs.c
 build out/ecs_test.o:  compile  ecs_test.c

--- a/ecs_test.c
+++ b/ecs_test.c
@@ -88,5 +88,57 @@ int main(void) {
     expect(tag.root == NULL);
     expect(component_find(&tag, 1) == NULL);
 
+    struct component drop_end = {.size = sizeof(int)};
+    for (int i = 1; i <= 3; ++i) {
+        int *val = component_data(&drop_end, i);
+        *val = i;
+    }
+    component_drop(&drop_end, 3);
+    expect(component_find(&drop_end, 3) == NULL);
+    expect(component_find(&drop_end, 2) != NULL);
+    for (int i = 1; i <= 2; ++i) {
+        component_drop(&drop_end, i);
+    }
+
+    struct component merge = {.size = sizeof(int)};
+    int *v1 = component_data(&merge, 1);
+    *v1 = 1;
+    int *v2 = component_data(&merge, 2);
+    *v2 = 2;
+    int *v4 = component_data(&merge, 4);
+    *v4 = 4;
+    int *v5 = component_data(&merge, 5);
+    *v5 = 5;
+    int *v3 = component_data(&merge, 3);
+    *v3 = 3;
+    int sum = 0;
+    component_each(&merge, sum_fn, &sum);
+    expect(sum == 15);
+    for (int i = 1; i <= 5; ++i) {
+        component_drop(&merge, i);
+    }
+
+    struct component rot_l = {.size = 0};
+    component_data(&rot_l, 30);
+    component_data(&rot_l, 20);
+    component_data(&rot_l, 10);
+    expect(component_find(&rot_l, 10) != NULL);
+    expect(component_find(&rot_l, 20) != NULL);
+    expect(component_find(&rot_l, 30) != NULL);
+    component_drop(&rot_l, 10);
+    component_drop(&rot_l, 20);
+    component_drop(&rot_l, 30);
+
+    struct component rot_r = {.size = 0};
+    component_data(&rot_r, 10);
+    component_data(&rot_r, 20);
+    component_data(&rot_r, 30);
+    expect(component_find(&rot_r, 10) != NULL);
+    expect(component_find(&rot_r, 20) != NULL);
+    expect(component_find(&rot_r, 30) != NULL);
+    component_drop(&rot_r, 10);
+    component_drop(&rot_r, 20);
+    component_drop(&rot_r, 30);
+
     return 0;
 }


### PR DESCRIPTION
## Summary
- collect coverage using clang's instrumentation
- add new scenarios to ecs_test to cover previously untested paths

## Testing
- `ninja -v`
- `LLVM_PROFILE_FILE=out/ecs_test.profraw ./out/ecs_test > out/ecs_test.ok`


------
https://chatgpt.com/codex/tasks/task_e_686a4393aca8832680a2c5d6801e6e97