### PR TITLE
Add tests for merge and shrink paths

### DIFF
--- a/ecs_test.c
+++ b/ecs_test.c
@@ -228,6 +228,43 @@ static void test_succ_with_pred(void) {
     expect(c.root == NULL);
 }
 
+static void test_merge_pred_succ_fit(void) {
+    struct component c = {.size = sizeof(int)};
+    int *v1 = component_data(&c, 1);
+    *v1 = 1;
+    int *v2 = component_data(&c, 2);
+    *v2 = 2;
+    int *v4 = component_data(&c, 4);
+    *v4 = 4;
+    int *v3 = component_data(&c, 3);
+    *v3 = 3;
+    for (int i = 1; i <= 4; ++i) {
+        int *val = component_find(&c, i);
+        expect(val != NULL);
+        expect(*val == i);
+    }
+    for (int i = 1; i <= 4; ++i) {
+        component_drop(&c, i);
+    }
+    expect(c.root == NULL);
+}
+
+static void test_shrink_last_drop(void) {
+    struct component c = {.size = sizeof(int)};
+    for (int i = 1; i <= 5; ++i) {
+        int *val = component_data(&c, i);
+        *val = i;
+    }
+    component_drop(&c, 5);
+    component_drop(&c, 4);
+    component_drop(&c, 3);
+    expect(component_find(&c, 3) == NULL);
+    for (int i = 1; i <= 2; ++i) {
+        component_drop(&c, i);
+    }
+    expect(c.root == NULL);
+}
+
 int main(void) {
     test_int_component();
     test_tag_component();
@@ -240,5 +277,7 @@ int main(void) {
     test_remove_min();
     test_succ_no_pred();
     test_succ_with_pred();
+    test_merge_pred_succ_fit();
+    test_shrink_last_drop();
     return 0;
 }


### PR DESCRIPTION
## Summary
- add coverage for merging adjacent branches when capacity allows
- add coverage for shrinking branch capacity when dropping the last element

## Testing
- `ninja out/ecs_test.ok`

------
https://chatgpt.com/codex/tasks/task_e_686a529bcf148326a4f682fdffe16572