### PR TITLE
Optimize drop front of branch

### DIFF
--- a/ecs.c
+++ b/ecs.c
@@ -241,40 +241,30 @@ void component_drop(struct component *c, int i) {
             return;
         }
 
+        if (b->begin != i && b->end != i+1) {
+            struct branch *L = branch_new(b->begin, i, c->size, 0);
+            struct branch *R = branch_new(i+1, b->end, c->size, 0);
+            memcpy(L->data, branch_ptr(b,c->size,b->begin), (size_t)(i  -  b->begin) * c->size);
+            memcpy(R->data, branch_ptr(b,c->size,     i+1), (size_t)(b->end - (i+1)) * c->size);
+            component_remove_branch(c, b);
+            component_insert_branch(c, L);
+            component_insert_branch(c, R);
+            return;
+        }
+
         if (b->begin == i) {
-            memmove(b->data,
-                    branch_ptr(b, c->size, i+1),
-                    (size_t)(b->end - (i+1)) * c->size);
             b->begin += 1;
-            if (b->end - b->begin <= b->cap / 4 && b->cap > 1) {
-                struct branch *shrunk = branch_new(b->begin, b->end, c->size, b->cap/2);
-                memcpy(shrunk->data,
-                       b->data,
-                       (size_t)(b->end - b->begin) * c->size);
-                component_remove_branch(c, b);
-                component_insert_branch(c, shrunk);
-            }
-            return;
-        }
-
-        if (b->end == i+1) {
+            memmove(b->data, b->data + c->size, (size_t)(b->end - (i+1)) * c->size);
+        } else if (b->end == i+1) {
             b->end -= 1;
-            if (b->end - b->begin <= b->cap / 4 && b->cap > 1) {
-                struct branch *shrunk = branch_new(b->begin, b->end, c->size, b->cap/2);
-                memcpy(shrunk->data, b->data, (size_t)(b->end - b->begin) * c->size);
-                component_remove_branch(c, b);
-                component_insert_branch(c, shrunk);
-            }
-            return;
         }
 
-        struct branch *L = branch_new(b->begin, i, c->size, 0);
-        struct branch *R = branch_new(i+1, b->end, c->size, 0);
-        memcpy(L->data, branch_ptr(b,c->size,b->begin), (size_t)(i  -  b->begin) * c->size);
-        memcpy(R->data, branch_ptr(b,c->size,     i+1), (size_t)(b->end - (i+1)) * c->size);
-        component_remove_branch(c, b);
-        component_insert_branch(c, L);
-        component_insert_branch(c, R);
+        if (b->end - b->begin <= b->cap / 4 && b->cap > 1) {
+            struct branch *shrunk = branch_new(b->begin, b->end, c->size, b->cap/2);
+            memcpy(shrunk->data, b->data, (size_t)(b->end - b->begin) * c->size);
+            component_remove_branch(c, b);
+            component_insert_branch(c, shrunk);
+        }
     }
 }
 

--- a/ecs.c
+++ b/ecs.c
@@ -242,10 +242,18 @@ void component_drop(struct component *c, int i) {
         }
 
         if (b->begin == i) {
-            struct branch *shrunk = branch_new(i+1, b->end, c->size, 0);
-            memcpy(shrunk->data, branch_ptr(b,c->size,i+1), (size_t)(b->end - (i+1)) * c->size);
-            component_remove_branch(c, b);
-            component_insert_branch(c, shrunk);
+            memmove(b->data,
+                    branch_ptr(b, c->size, i+1),
+                    (size_t)(b->end - (i+1)) * c->size);
+            b->begin += 1;
+            if (b->end - b->begin <= b->cap / 4 && b->cap > 1) {
+                struct branch *shrunk = branch_new(b->begin, b->end, c->size, b->cap/2);
+                memcpy(shrunk->data,
+                       b->data,
+                       (size_t)(b->end - b->begin) * c->size);
+                component_remove_branch(c, b);
+                component_insert_branch(c, shrunk);
+            }
             return;
         }
 

--- a/ecs_test.c
+++ b/ecs_test.c
@@ -249,6 +249,21 @@ static void test_shrink_last_drop(void) {
     component_free(&c);
 }
 
+static void test_shrink_first_drop(void) {
+    struct component c = {.size = sizeof(int)};
+    for (int i = 1; i <= 5; ++i) {
+        int *val = component_data(&c, i);
+        *val = i;
+    }
+    component_drop(&c, 1);
+    component_drop(&c, 2);
+    component_drop(&c, 3);
+    expect(component_find(&c, 3) == NULL);
+    int *v4 = component_find(&c, 4);
+    expect(v4 != NULL && *v4 == 4);
+    component_free(&c);
+}
+
 int main(void) {
     test_int_component();
     test_tag_component();
@@ -264,5 +279,6 @@ int main(void) {
     test_succ_with_pred();
     test_merge_pred_succ_fit();
     test_shrink_last_drop();
+    test_shrink_first_drop();
     return 0;
 }


### PR DESCRIPTION
## Summary
- shrink a branch at the front without a new allocation
- reuse the same shrink check as the end case

## Testing
- `ninja -k0 out/ecs_test.ok`

------
https://chatgpt.com/codex/tasks/task_e_686a5ea48fc483269353b8fb6f3bfa93