### PR TITLE
Add coverage for avl_remove left branch

### DIFF
--- a/ecs_test.c
+++ b/ecs_test.c
@@ -218,6 +218,18 @@ static void test_succ_with_pred(void) {
     component_free(&c);
 }
 
+static void test_remove_left_child(void) {
+    struct component c = {.size = sizeof(int)};
+    int *v20 = component_data(&c, 20);
+    *v20 = 20;
+    int *v10 = component_data(&c, 10);
+    *v10 = 10;
+    component_drop(&c, 10);
+    expect(component_find(&c, 10) == NULL);
+    expect(component_find(&c, 20) != NULL);
+    component_free(&c);
+}
+
 static void test_merge_pred_succ_fit(void) {
     struct component c = {.size = sizeof(int)};
     int *v1 = component_data(&c, 1);
@@ -277,6 +289,7 @@ int main(void) {
     test_remove_min();
     test_succ_no_pred();
     test_succ_with_pred();
+    test_remove_left_child();
     test_merge_pred_succ_fit();
     test_shrink_last_drop();
     test_shrink_first_drop();


### PR DESCRIPTION
## Summary
- add test_remove_left_child to hit left branch removal
- include new test in test suite to improve coverage

## Testing
- `ninja`
- `llvm-profdata merge -sparse out/ecs_test.profraw -o out/ecs_test.profdata`
- `llvm-cov show ./out/ecs_test -instr-profile=out/ecs_test.profdata ecs.c | sed -n '90,100p'`

------
https://chatgpt.com/codex/tasks/task_e_686a69339d8c8326b120e7c367dc1155