### PR TITLE
Add data array to index

### DIFF
--- a/index.c
+++ b/index.c
@@ -22,13 +22,13 @@ int index_insert(struct index *ix, int key) {
     }
 
     if (is_pow2_or_zero(ix->vals)) {
-        size_t cap = ix->vals ? 2u*(size_t)ix->vals : 1u;
+        size_t const cap = ix->vals ? 2*(size_t)ix->vals : 1;
+        ix->data  = realloc(ix->data,  cap *         ix->elt  );
         ix->dense = realloc(ix->dense, cap * sizeof *ix->dense);
-        ix->data  = realloc(ix->data,  cap * ix->elt);
     }
 
     int const val = ix->vals++;
-    ix->dense[val] = key;
+    ix->dense [val] = key;
     ix->sparse[key] = val;
     return val;
 }
@@ -42,12 +42,8 @@ void index_remove(struct index *ix, int key) {
         if (val != back_val) {
             ix->dense[val] = back_key;
             ix->sparse[back_key] = val;
-            if (ix->elt) {
-                char *data = ix->data;
-                size_t const off = (size_t)val * ix->elt,
-                               back_off = (size_t)back_val * ix->elt;
-                memcpy(data + off, data + back_off, ix->elt);
-            }
+            memcpy((char      *)ix->data + (size_t)     val * ix->elt,
+                   (char const*)ix->data + (size_t)back_val * ix->elt, ix->elt);
         }
     }
 }

--- a/index.h
+++ b/index.h
@@ -1,9 +1,13 @@
 #pragma once
 
+#include <stddef.h>
+
 struct index {
-    int *sparse;
-    int *dense;
-    int  vals, max_key;
+    int   *sparse;
+    int   *dense;
+    void  *data;
+    size_t elt;
+    int    vals, max_key;
 };
 
 int  index_insert(struct index       *index, int key);

--- a/index.h
+++ b/index.h
@@ -3,11 +3,11 @@
 #include <stddef.h>
 
 struct index {
-    int   *sparse;
-    int   *dense;
     void  *data;
     size_t elt;
     int    vals, max_key;
+    int   *dense;
+    int   *sparse;
 };
 
 int  index_insert(struct index       *index, int key);

--- a/index_test.c
+++ b/index_test.c
@@ -2,37 +2,56 @@
 #include "test.h"
 #include <stdlib.h>
 
+struct point { float x,y; };
+
+static struct point* val_at(struct index *ix, int idx) {
+    struct point *p = ix->data;
+    return p + idx;
+}
+
 int main(void) {
-    struct index index = {0};
+    struct index ix = {.elt = sizeof(struct point)};
 
-    expect(0 == index_insert(&index, 47));
-    expect(1 == index_insert(&index, 42));
-    expect(2 == index_insert(&index, 48));
-    expect(3 == index_insert(&index, 50));
+    expect(0 == index_insert(&ix, 47));
+    *val_at(&ix, 0) = (struct point){47.0f, -47.0f};
 
-    expect(0 == index_lookup(&index, 47));
-    expect(1 == index_lookup(&index, 42));
-    expect(2 == index_lookup(&index, 48));
-    expect(3 == index_lookup(&index, 50));
+    expect(1 == index_insert(&ix, 42));
+    *val_at(&ix, 1) = (struct point){42.0f, -42.0f};
 
-    expect(~0 == index_lookup(&index, 23));
-    expect(~0 == index_lookup(&index, 51));
+    expect(2 == index_insert(&ix, 48));
+    *val_at(&ix, 2) = (struct point){48.0f, -48.0f};
 
-    index_remove(&index, 42);
-    expect(~0 == index_lookup(&index, 42));
-    expect(1 == index_lookup(&index, 50));
-    expect(0 == index_lookup(&index, 47));
-    expect(2 == index_lookup(&index, 48));
+    expect(3 == index_insert(&ix, 50));
+    *val_at(&ix, 3) = (struct point){50.0f, -50.0f};
 
-    index_remove(&index, 42);
-    expect(~0 == index_lookup(&index, 42));
+    expect(0 == index_lookup(&ix, 47));
+    expect(1 == index_lookup(&ix, 42));
+    expect(2 == index_lookup(&ix, 48));
+    expect(3 == index_lookup(&ix, 50));
 
-    index_remove(&index, 48);
-    expect(~0 == index_lookup(&index, 48));
-    expect(0 == index_lookup(&index, 47));
-    expect(1 == index_lookup(&index, 50));
+    expect((int)val_at(&ix, index_lookup(&ix, 47))->y == -47);
+    expect((int)val_at(&ix, index_lookup(&ix, 50))->y == -50);
 
-    free(index.sparse);
-    free(index.dense);
+    index_remove(&ix, 42);
+    expect(~0 == index_lookup(&ix, 42));
+    expect(1 == index_lookup(&ix, 50));
+    expect((int)val_at(&ix, 1)->x == 50);
+    expect(0 == index_lookup(&ix, 47));
+    expect((int)val_at(&ix, 0)->x == 47);
+    expect(2 == index_lookup(&ix, 48));
+
+    index_remove(&ix, 42);
+    expect(~0 == index_lookup(&ix, 42));
+
+    index_remove(&ix, 48);
+    expect(~0 == index_lookup(&ix, 48));
+    expect(0 == index_lookup(&ix, 47));
+    expect((int)val_at(&ix, 0)->x == 47);
+    expect(1 == index_lookup(&ix, 50));
+    expect((int)val_at(&ix, 1)->x == 50);
+
+    free(ix.sparse);
+    free(ix.dense);
+    free(ix.data);
     return 0;
 }

--- a/index_test.c
+++ b/index_test.c
@@ -24,31 +24,32 @@ int main(void) {
     expect(3 == index_insert(&ix, 50));
     *val_at(&ix, 3) = (struct point){50.0f, -50.0f};
 
-    expect(0 == index_lookup(&ix, 47));
-    expect(1 == index_lookup(&ix, 42));
-    expect(2 == index_lookup(&ix, 48));
-    expect(3 == index_lookup(&ix, 50));
+    expect( 0 == index_lookup(&ix, 47));
+    expect( 1 == index_lookup(&ix, 42));
+    expect( 2 == index_lookup(&ix, 48));
+    expect( 3 == index_lookup(&ix, 50));
+    expect(~0 == index_lookup(&ix, 51));
 
     expect((int)val_at(&ix, index_lookup(&ix, 47))->y == -47);
     expect((int)val_at(&ix, index_lookup(&ix, 50))->y == -50);
 
     index_remove(&ix, 42);
     expect(~0 == index_lookup(&ix, 42));
-    expect(1 == index_lookup(&ix, 50));
+    expect( 1 == index_lookup(&ix, 50));
     expect((int)val_at(&ix, 1)->x == 50);
-    expect(0 == index_lookup(&ix, 47));
+    expect( 0 == index_lookup(&ix, 47));
     expect((int)val_at(&ix, 0)->x == 47);
-    expect(2 == index_lookup(&ix, 48));
+    expect( 2 == index_lookup(&ix, 48));
 
     index_remove(&ix, 42);
     expect(~0 == index_lookup(&ix, 42));
 
     index_remove(&ix, 48);
     expect(~0 == index_lookup(&ix, 48));
-    expect(0 == index_lookup(&ix, 47));
-    expect((int)val_at(&ix, 0)->x == 47);
-    expect(1 == index_lookup(&ix, 50));
-    expect((int)val_at(&ix, 1)->x == 50);
+    expect( 0 == index_lookup(&ix, 47));
+    expect( (int)val_at(&ix, 0)->x == 47);
+    expect( 1 == index_lookup(&ix, 50));
+    expect( (int)val_at(&ix, 1)->x == 50);
 
     free(ix.sparse);
     free(ix.dense);


### PR DESCRIPTION
## Summary
- extend `struct index` with a `data` array parallel to `dense`
- grow and compact `data` alongside `dense`
- test `index` using a `struct point` payload

## Testing
- `ninja out/index_test.ok out/ecs_test.ok`

------
https://chatgpt.com/codex/tasks/task_e_686a9c54583883269b77e52f4edcb3fc