### PR TITLE
Refactor index API for direct data copy/lookup

### DIFF
--- a/index.h
+++ b/index.h
@@ -10,6 +10,6 @@ struct index {
     int   *sparse;
 };
 
-int  index_insert(struct index       *index, int key);
-void index_remove(struct index       *index, int key);
-int  index_lookup(struct index const *index, int key);
+int   index_insert(struct index       *index, int key, void const *src);
+void  index_remove(struct index       *index, int key);
+void* index_lookup(struct index const *index, int key);

--- a/index_test.c
+++ b/index_test.c
@@ -4,52 +4,56 @@
 
 struct point { float x,y; };
 
-static struct point* val_at(struct index *ix, int idx) {
-    struct point *p = ix->data;
-    return p + idx;
-}
-
 int main(void) {
     struct index ix = {.elt = sizeof(struct point)};
 
-    expect(0 == index_insert(&ix, 47));
-    *val_at(&ix, 0) = (struct point){47.0f, -47.0f};
+    struct point p;
+    p = (struct point){47.0f, -47.0f};
+    expect(0 == index_insert(&ix, 47, &p));
 
-    expect(1 == index_insert(&ix, 42));
-    *val_at(&ix, 1) = (struct point){42.0f, -42.0f};
+    p = (struct point){42.0f, -42.0f};
+    expect(1 == index_insert(&ix, 42, &p));
 
-    expect(2 == index_insert(&ix, 48));
-    *val_at(&ix, 2) = (struct point){48.0f, -48.0f};
+    p = (struct point){48.0f, -48.0f};
+    expect(2 == index_insert(&ix, 48, &p));
 
-    expect(3 == index_insert(&ix, 50));
-    *val_at(&ix, 3) = (struct point){50.0f, -50.0f};
+    p = (struct point){50.0f, -50.0f};
+    expect(3 == index_insert(&ix, 50, &p));
 
-    expect( 0 == index_lookup(&ix, 47));
-    expect( 1 == index_lookup(&ix, 42));
-    expect( 2 == index_lookup(&ix, 48));
-    expect( 3 == index_lookup(&ix, 50));
-    expect(~0 == index_lookup(&ix, 51));
+    struct point* r;
+    r = index_lookup(&ix, 47);
+    expect(r && (int)r->x == 47 && (int)r->y == -47);
+    r = index_lookup(&ix, 42);
+    expect(r && (int)r->y == -42);
+    r = index_lookup(&ix, 48);
+    expect(r && (int)r->y == -48);
+    r = index_lookup(&ix, 50);
+    expect(r && (int)r->y == -50);
+    expect(!index_lookup(&ix, 51));
 
-    expect((int)val_at(&ix, index_lookup(&ix, 47))->y == -47);
-    expect((int)val_at(&ix, index_lookup(&ix, 50))->y == -50);
+    r = index_lookup(&ix, 47);
+    expect(r && (int)r->y == -47);
+    r = index_lookup(&ix, 50);
+    expect(r && (int)r->y == -50);
 
     index_remove(&ix, 42);
-    expect(~0 == index_lookup(&ix, 42));
-    expect( 1 == index_lookup(&ix, 50));
-    expect((int)val_at(&ix, 1)->x == 50);
-    expect( 0 == index_lookup(&ix, 47));
-    expect((int)val_at(&ix, 0)->x == 47);
-    expect( 2 == index_lookup(&ix, 48));
+    expect(!index_lookup(&ix, 42));
+    r = index_lookup(&ix, 50);
+    expect(r && (int)r->x == 50);
+    r = index_lookup(&ix, 47);
+    expect(r && (int)r->x == 47);
+    r = index_lookup(&ix, 48);
+    expect(r && (int)r->x == 48);
 
     index_remove(&ix, 42);
-    expect(~0 == index_lookup(&ix, 42));
+    expect(!index_lookup(&ix, 42));
 
     index_remove(&ix, 48);
-    expect(~0 == index_lookup(&ix, 48));
-    expect( 0 == index_lookup(&ix, 47));
-    expect( (int)val_at(&ix, 0)->x == 47);
-    expect( 1 == index_lookup(&ix, 50));
-    expect( (int)val_at(&ix, 1)->x == 50);
+    expect(!index_lookup(&ix, 48));
+    r = index_lookup(&ix, 47);
+    expect(r && (int)r->x == 47);
+    r = index_lookup(&ix, 50);
+    expect(r && (int)r->x == 50);
 
     free(ix.sparse);
     free(ix.dense);


### PR DESCRIPTION
## Summary
- let `index_insert` copy provided data directly
- have `index_lookup` return a pointer to stored data
- adapt tests to new API

## Testing
- `ninja -v out/index_test.ok out/ecs_test.ok`
- `ninja -v out/ecs_bench`

------
https://chatgpt.com/codex/tasks/task_e_686aa15f5d648326b90dd196a4c42429