### PR TITLE
Allocate table arrays together

### DIFF
--- a/ecs.h
+++ b/ecs.h
@@ -3,8 +3,8 @@
 #include <stddef.h>
 
 struct table {
-    size_t size;
-    void  *data;
+    size_t size,cap;
+    void *data;
     int    n,slots;
     int   *key,*ix;
 };


### PR DESCRIPTION
## Summary
- remove TODO by storing table key/data in a single allocation
- track capacity for reallocation
- free only once in `table_clear`

## Testing
- `ninja -f build.ninja out/test.ok`
- `ninja -f build.ninja out/bench`

------
https://chatgpt.com/codex/tasks/task_e_686ac0cc8d508326bb5350118e92d6d6