### PR TITLE
Add table_join with tests and benchmarks

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -28,3 +28,6 @@
      }
 
 - Match existing code style; avoid purely stylistic changes like spacing around operators.
+
+- Use the singular for array-style pointers and the plural for their matching
+  integer count.  For example `struct table const *table[]` and `int tables`.

--- a/bench.c
+++ b/bench.c
@@ -43,6 +43,112 @@ static double bench_sparse(int n) {
     return elapsed;
 }
 
+struct sum_ctx { int tables,sum; };
+
+static void add(int key, void* const row[], void *ctx) {
+    struct sum_ctx *s = ctx;
+    (void)key;
+    for (int i = 0; i < s->tables; ++i) {
+        if (row[i]) {
+            s->sum += *(int*)row[i];
+        }
+    }
+}
+
+static double bench_iter(int n) {
+    struct table t = {.size = sizeof(int)};
+    for (int i = 0; i < n; ++i) {
+        table_set(&t, i, &i);
+    }
+    struct sum_ctx ctx = {.tables = 1};
+    struct table const *table[] = {&t};
+    double const start = now();
+    table_join(table, 1, &ctx, add);
+    double const elapsed = now() - start;
+    table_reset(&t);
+    return elapsed + ctx.sum*0;
+}
+
+static double bench_join2_equal(int n) {
+    struct table a = {.size = sizeof(int)};
+    struct table b = {.size = sizeof(int)};
+    for (int i = 0; i < n; ++i) {
+        table_set(&a, i, &i);
+        table_set(&b, i, &i);
+    }
+    struct sum_ctx ctx = {.tables = 2};
+    struct table const *table[] = {&a,&b};
+    double const start = now();
+    table_join(table, 2, &ctx, add);
+    double const elapsed = now() - start;
+    table_reset(&a);
+    table_reset(&b);
+    return elapsed + ctx.sum*0;
+}
+
+static double bench_join2_diff(int n) {
+    struct table big   = {.size = sizeof(int)};
+    struct table small = {.size = sizeof(int)};
+    for (int i = 0; i < n; ++i) {
+        table_set(&big, i, &i);
+    }
+    for (int i = 0; i < n; i += 4) {
+        table_set(&small, i, &i);
+    }
+    struct sum_ctx ctx = {.tables = 2};
+    struct table const *table[] = {&big,&small};
+    double const start = now();
+    table_join(table, 2, &ctx, add);
+    double const elapsed = now() - start;
+    table_reset(&big);
+    table_reset(&small);
+    return elapsed + ctx.sum*0;
+}
+
+static double bench_join3_equal(int n) {
+    struct table a = {.size = sizeof(int)};
+    struct table b = {.size = sizeof(int)};
+    struct table c = {.size = sizeof(int)};
+    for (int i = 0; i < n; ++i) {
+        table_set(&a, i, &i);
+        table_set(&b, i, &i);
+        table_set(&c, i, &i);
+    }
+    struct sum_ctx ctx = {.tables = 3};
+    struct table const *table[] = {&a,&b,&c};
+    double const start = now();
+    table_join(table, 3, &ctx, add);
+    double const elapsed = now() - start;
+    table_reset(&a);
+    table_reset(&b);
+    table_reset(&c);
+    return elapsed + ctx.sum*0;
+}
+
+static double bench_join3_diff(int n) {
+    struct table big  = {.size = sizeof(int)};
+    struct table mid  = {.size = sizeof(int)};
+    struct table tiny = {.size = sizeof(int)};
+    for (int i = 0; i < n; ++i) {
+        table_set(&big, i, &i);
+    }
+    for (int i = 0; i < n; i += 2) {
+        table_set(&mid, i, &i);
+    }
+    for (int i = 0; i < n; i += 4) {
+        table_set(&tiny, i, &i);
+    }
+    struct sum_ctx ctx = {.tables = 3};
+    struct table const *table[] = {&big,&mid,&tiny};
+    double const start = now();
+    table_join(table, 3, &ctx, add);
+    double const elapsed = now() - start;
+    table_reset(&big);
+    table_reset(&mid);
+    table_reset(&tiny);
+    return elapsed + ctx.sum*0;
+}
+
 static void run(char const *name, double (*fn)(int)) {
     printf("%s\n", name);
     printf("%8s  %8s\n", "n", "sec");
@@ -57,5 +163,10 @@ int main(void) {
     run("dense",     bench_dense);
     run("dense_rev", bench_dense_rev);
     run("sparse",    bench_sparse);
+    run("iter",      bench_iter);
+    run("join2",     bench_join2_equal);
+    run("join2d",    bench_join2_diff);
+    run("join3",     bench_join3_equal);
+    run("join3d",    bench_join3_diff);
     return 0;
 }

--- a/ecs.h
+++ b/ecs.h
@@ -13,3 +13,5 @@ void* table_get  (struct table const *table, int key);
 void  table_set  (struct table       *table, int key, void const *val);
 void  table_del  (struct table       *table, int key);
 void  table_reset(struct table       *table);
+void  table_join(struct table const *table[], int tables, void *ctx,
+                void (*fn)(int, void* const*, void*));


### PR DESCRIPTION
## Summary
- implement `table_join()` to iterate across multiple tables
- add unit tests exercising table joining
- benchmark iteration and joining various table configurations
- document singular/plural pointer naming convention in `AGENTS.md`

## Testing
- `ninja -j1 out/test.ok`
- `ninja -j1 out/bench`
- `./out/bench | head -n 20`

------
https://chatgpt.com/codex/tasks/task_e_686b915a4f3c832688e8b843d97c61de