### PR TITLE
Add table_join with tests and benchmarks

### DIFF
--- a/bench.c
+++ b/bench.c
@@ -43,10 +43,6 @@ static double bench_sparse(int n) {
     return elapsed;
 }
 
-static void noop(int key, void *vals, void *ctx) {
-    (void)key; (void)vals; (void)ctx;
-}
-
 static double bench_join(int n) {
     struct table a = {.size = sizeof(int)};
     struct table b = {.size = sizeof(int)};
@@ -57,7 +53,9 @@ static double bench_join(int n) {
     struct table const *table[] = {&a,&b};
     int vals[2];
     double const start = now();
-    table_join(table, 2, noop, vals, NULL);
+    for (int key = 0; table_join(table, 2, &key, vals);) {
+        (void)vals;
+    }
     double const elapsed = now() - start;
     table_reset(&a);
     table_reset(&b);

--- a/bench.c
+++ b/bench.c
@@ -43,6 +43,27 @@ static double bench_sparse(int n) {
     return elapsed;
 }
 
+static void noop(int key, void* val[], void *ctx) {
+    (void)key; (void)val; (void)ctx;
+}
+
+static double bench_join(int n) {
+    struct table a = {.size = sizeof(int)};
+    struct table b = {.size = sizeof(int)};
+    for (int i = 0; i < n; ++i) {
+        table_set(&a, i, &i);
+        table_set(&b, i, &i);
+    }
+    struct table const *table[] = {&a,&b};
+    void* val[2];
+    double const start = now();
+    table_join(table, 2, noop, val, NULL);
+    double const elapsed = now() - start;
+    table_reset(&a);
+    table_reset(&b);
+    return elapsed;
+}
+
 static void run(char const *name, double (*fn)(int)) {
     printf("%s\n", name);
     printf("%8s  %8s %8s\n", "n", "µs", "ns/n");
@@ -62,5 +83,6 @@ int main(void) {
     run("dense",     bench_dense);
     run("dense_rev", bench_dense_rev);
     run("sparse",    bench_sparse);
+    run("join",      bench_join);
     return 0;
 }

--- a/bench.c
+++ b/bench.c
@@ -43,8 +43,8 @@ static double bench_sparse(int n) {
     return elapsed;
 }
 
-static void noop(int key, void* val[], void *ctx) {
-    (void)key; (void)val; (void)ctx;
+static void noop(int key, void *vals, void *ctx) {
+    (void)key; (void)vals; (void)ctx;
 }
 
 static double bench_join(int n) {
@@ -55,9 +55,9 @@ static double bench_join(int n) {
         table_set(&b, i, &i);
     }
     struct table const *table[] = {&a,&b};
-    void* val[2];
+    int vals[2];
     double const start = now();
-    table_join(table, 2, noop, val, NULL);
+    table_join(table, 2, noop, vals, NULL);
     double const elapsed = now() - start;
     table_reset(&a);
     table_reset(&b);

--- a/ecs.c
+++ b/ecs.c
@@ -62,8 +62,8 @@ void table_reset(struct table *t) {
 }
 
 void table_join(struct table const *table[], int tables,
-                void (*cb)(int key, void* val[], void *ctx),
-                void* val[], void *ctx) {
+                void (*cb)(int key, void *vals, void *ctx),
+                void *vals, void *ctx) {
     struct table seen = {0};
     for (int i = 0; i < tables; i++) {
         struct table const *t = table[i];
@@ -71,10 +71,16 @@ void table_join(struct table const *table[], int tables,
             int const key = t->key[ix];
             if (!table_get(&seen, key)) {
                 table_set(&seen, key, NULL);
+                size_t offset = 0;
                 for (int j = 0; j < tables; j++) {
-                    val[j] = table_get(table[j], key);
+                    void *src = table_get(table[j], key);
+                    void *dst = (char *)vals + offset;
+                    size_t const sz = table[j]->size;
+                    if (src) { memcpy(dst, src, sz); }
+                    else { memset(dst, 0, sz); }
+                    offset += sz;
                 }
-                cb(key, val, ctx);
+                cb(key, vals, ctx);
             }
         }
     }

--- a/ecs.c
+++ b/ecs.c
@@ -60,3 +60,23 @@ void table_reset(struct table *t) {
     }
     *t = (struct table){.size=t->size};
 }
+
+void table_join(struct table const *table[], int tables,
+                void (*cb)(int key, void* val[], void *ctx),
+                void* val[], void *ctx) {
+    struct table seen = {0};
+    for (int i = 0; i < tables; i++) {
+        struct table const *t = table[i];
+        for (int ix = 0; ix < t->n; ix++) {
+            int const key = t->key[ix];
+            if (!table_get(&seen, key)) {
+                table_set(&seen, key, NULL);
+                for (int j = 0; j < tables; j++) {
+                    val[j] = table_get(table[j], key);
+                }
+                cb(key, val, ctx);
+            }
+        }
+    }
+    table_reset(&seen);
+}

--- a/ecs.h
+++ b/ecs.h
@@ -13,3 +13,6 @@ void* table_get  (struct table const *table, int key);
 void  table_set  (struct table       *table, int key, void const *val);
 void  table_del  (struct table       *table, int key);
 void  table_reset(struct table       *table);
+void  table_join (struct table const *table[], int tables,
+                  void (*cb)(int key, void* val[], void *ctx),
+                  void* val[], void *ctx);

--- a/ecs.h
+++ b/ecs.h
@@ -14,5 +14,5 @@ void  table_set  (struct table       *table, int key, void const *val);
 void  table_del  (struct table       *table, int key);
 void  table_reset(struct table       *table);
 void  table_join (struct table const *table[], int tables,
-                  void (*cb)(int key, void* val[], void *ctx),
-                  void* val[], void *ctx);
+                  void (*cb)(int key, void *vals, void *ctx),
+                  void *vals, void *ctx);

--- a/ecs.h
+++ b/ecs.h
@@ -13,6 +13,4 @@ void* table_get  (struct table const *table, int key);
 void  table_set  (struct table       *table, int key, void const *val);
 void  table_del  (struct table       *table, int key);
 void  table_reset(struct table       *table);
-void  table_join (struct table const *table[], int tables,
-                  void (*cb)(int key, void *vals, void *ctx),
-                  void *vals, void *ctx);
+_Bool table_join(struct table const *table[], int tables, int *key, void *vals);

--- a/test.c
+++ b/test.c
@@ -97,13 +97,14 @@ static void test_tag_table(void) {
 struct join_row { int key,a,b,c; };
 struct join_ctx { int ix; int :32; struct join_row *row; };
 
-static void join_collect(int key, void* val[], void *ctx) {
+static void join_collect(int key, void *vals, void *ctx) {
     struct join_ctx *c = ctx;
     struct join_row *row = c->row + c->ix++;
+    int const *v = vals;
     row->key = key;
-    row->a = val[0] ? *(int*)val[0] : -1;
-    row->b = val[1] ? *(int*)val[1] : -1;
-    row->c = val[2] ? *(int*)val[2] : -1;
+    row->a = v[0];
+    row->b = v[1];
+    row->c = v[2];
 }
 
 static void test_table_join(void) {
@@ -118,14 +119,14 @@ static void test_table_join(void) {
 
     struct table const *table[] = {&a,&b,&c};
     struct join_row got[3] = {0};
-    void* val[3];
+    int vals[3];
     struct join_ctx ctx = {0,got};
-    table_join(table, 3, join_collect, val, &ctx);
+    table_join(table, 3, join_collect, vals, &ctx);
 
     expect(ctx.ix == 3);
-    expect(got[0].key == 1 && got[0].a == 10 && got[0].b == 100 && got[0].c == -1);
-    expect(got[1].key == 3 && got[1].a == 30 && got[1].b == -1 && got[1].c == 300);
-    expect(got[2].key == 2 && got[2].a == -1 && got[2].b == 200 && got[2].c == -1);
+    expect(got[0].key == 1 && got[0].a == 10 && got[0].b == 100 && got[0].c == 0);
+    expect(got[1].key == 3 && got[1].a == 30 && got[1].b == 0 && got[1].c == 300);
+    expect(got[2].key == 2 && got[2].a == 0 && got[2].b == 200 && got[2].c == 0);
 
     table_reset(&a);
     table_reset(&b);

--- a/test.c
+++ b/test.c
@@ -94,8 +94,47 @@ static void test_tag_table(void) {
     table_reset(&tag);
 }
 
+struct join_row { int key,a,b,c; };
+struct join_ctx { int ix; int :32; struct join_row *row; };
+
+static void join_collect(int key, void* val[], void *ctx) {
+    struct join_ctx *c = ctx;
+    struct join_row *row = c->row + c->ix++;
+    row->key = key;
+    row->a = val[0] ? *(int*)val[0] : -1;
+    row->b = val[1] ? *(int*)val[1] : -1;
+    row->c = val[2] ? *(int*)val[2] : -1;
+}
+
+static void test_table_join(void) {
+    struct table a = {.size = sizeof(int)};
+    struct table b = {.size = sizeof(int)};
+    struct table c = {.size = sizeof(int)};
+    table_set(&a, 1, &(int){10});
+    table_set(&a, 3, &(int){30});
+    table_set(&b, 1, &(int){100});
+    table_set(&b, 2, &(int){200});
+    table_set(&c, 3, &(int){300});
+
+    struct table const *table[] = {&a,&b,&c};
+    struct join_row got[3] = {0};
+    void* val[3];
+    struct join_ctx ctx = {0,got};
+    table_join(table, 3, join_collect, val, &ctx);
+
+    expect(ctx.ix == 3);
+    expect(got[0].key == 1 && got[0].a == 10 && got[0].b == 100 && got[0].c == -1);
+    expect(got[1].key == 3 && got[1].a == 30 && got[1].b == -1 && got[1].c == 300);
+    expect(got[2].key == 2 && got[2].a == -1 && got[2].b == 200 && got[2].c == -1);
+
+    table_reset(&a);
+    table_reset(&b);
+    table_reset(&c);
+}
+
 int main(void) {
     test_point_table();
     test_tag_table();
+    test_table_join();
     return 0;
 }

--- a/test.c
+++ b/test.c
@@ -95,17 +95,6 @@ static void test_tag_table(void) {
 }
 
 struct join_row { int key,a,b,c; };
-struct join_ctx { int ix; int :32; struct join_row *row; };
-
-static void join_collect(int key, void *vals, void *ctx) {
-    struct join_ctx *c = ctx;
-    struct join_row *row = c->row + c->ix++;
-    int const *v = vals;
-    row->key = key;
-    row->a = v[0];
-    row->b = v[1];
-    row->c = v[2];
-}
 
 static void test_table_join(void) {
     struct table a = {.size = sizeof(int)};
@@ -118,15 +107,20 @@ static void test_table_join(void) {
     table_set(&c, 3, &(int){300});
 
     struct table const *table[] = {&a,&b,&c};
-    struct join_row got[3] = {0};
+    struct join_row got[2] = {0};
     int vals[3];
-    struct join_ctx ctx = {0,got};
-    table_join(table, 3, join_collect, vals, &ctx);
+    int ix = 0;
+    for (int key = 0; table_join(table, 3, &key, vals);) {
+        got[ix].key = key;
+        got[ix].a = vals[0];
+        got[ix].b = vals[1];
+        got[ix].c = vals[2];
+        ix++;
+    }
 
-    expect(ctx.ix == 3);
+    expect(ix == 2);
     expect(got[0].key == 1 && got[0].a == 10 && got[0].b == 100 && got[0].c == 0);
     expect(got[1].key == 3 && got[1].a == 30 && got[1].b == 0 && got[1].c == 300);
-    expect(got[2].key == 2 && got[2].a == 0 && got[2].b == 200 && got[2].c == 0);
 
     table_reset(&a);
     table_reset(&b);


### PR DESCRIPTION
## Summary
- support joining tables on keys with `table_join`
- add performance benchmark for `table_join`
- add unit test exercising joins

## Testing
- `ninja -C . out/test.ok`
- `ninja -C . out/bench`

------
https://chatgpt.com/codex/tasks/task_e_686b9847b61c8326a00f2657309a66be