### PR TITLE
Add table_join benchmarks

### DIFF
--- a/bench.c
+++ b/bench.c
@@ -3,6 +3,9 @@
 #include <stdio.h>
 #include <time.h>
 
+#define len(x) (int)(sizeof x / sizeof *x)
+static volatile int sink;
+
 static double now(void) {
     struct timespec ts;
     clock_gettime(CLOCK_MONOTONIC, &ts);
@@ -43,6 +46,107 @@ static double bench_sparse(int n) {
     return elapsed;
 }
 
+static double bench_iter_direct(int n) {
+    struct table t = {.size = sizeof(int)};
+    for (int i = 0; i < n; i++) {
+        table_set(&t, i, &i);
+    }
+    double const start = now();
+    int sum = 0;
+    for (int i = 0; i < t.n; i++) {
+        sum += ((int*)t.data)[i];
+    }
+    sink += sum;
+    double const elapsed = now() - start;
+    table_reset(&t);
+    return elapsed;
+}
+
+static double bench_join_single(int n) {
+    struct table t = {.size = sizeof(int)};
+    for (int i = 0; i < n; i++) {
+        table_set(&t, i, &i);
+    }
+    struct table const *tables[] = {&t};
+    int key = ~0, val, sum = 0;
+    double const start = now();
+    while (table_join(tables, len(tables), &key, &val)) {
+        sum += val;
+    }
+    sink += sum;
+    double const elapsed = now() - start;
+    table_reset(&t);
+    return elapsed;
+}
+
+static double bench_join_equal(int n) {
+    struct table a = {.size = sizeof(int)};
+    struct table b = {.size = sizeof(int)};
+    for (int i = 0; i < n; i++) {
+        table_set(&a, i, &i);
+        table_set(&b, i, &i);
+    }
+    struct table const *tables[] = {&a,&b};
+    int key = ~0, vals[2], sum = 0;
+    double const start = now();
+    while (table_join(tables, len(tables), &key, vals)) {
+        sum += vals[0] + vals[1];
+    }
+    sink += sum;
+    double const elapsed = now() - start;
+    table_reset(&a);
+    table_reset(&b);
+    return elapsed;
+}
+
+static double bench_join_small_lead(int n) {
+    int const small_n = n / 2;
+    struct table small = {.size = sizeof(int)};
+    struct table large = {.size = sizeof(int)};
+    for (int i = 0; i < small_n; i++) {
+        table_set(&small, i, &i);
+        table_set(&large, i, &i);
+    }
+    for (int i = small_n; i < n; i++) {
+        table_set(&large, i, &i);
+    }
+    struct table const *tables[] = {&small,&large};
+    int key = ~0, vals[2], sum = 0;
+    double const start = now();
+    while (table_join(tables, len(tables), &key, vals)) {
+        sum += vals[0] + vals[1];
+    }
+    sink += sum;
+    double const elapsed = now() - start;
+    table_reset(&small);
+    table_reset(&large);
+    return elapsed;
+}
+
+static double bench_join_large_lead(int n) {
+    int const small_n = n / 2;
+    struct table large = {.size = sizeof(int)};
+    struct table small = {.size = sizeof(int)};
+    for (int i = 0; i < small_n; i++) {
+        table_set(&large, i, &i);
+        table_set(&small, i, &i);
+    }
+    for (int i = small_n; i < n; i++) {
+        table_set(&large, i, &i);
+    }
+    struct table const *tables[] = {&large,&small};
+    int key = ~0, vals[2], sum = 0;
+    double const start = now();
+    while (table_join(tables, len(tables), &key, vals)) {
+        sum += vals[0] + vals[1];
+    }
+    sink += sum;
+    double const elapsed = now() - start;
+    table_reset(&large);
+    table_reset(&small);
+    return elapsed;
+}
+
 static void run(char const *name, double (*fn)(int)) {
     int const samples = 4;
     printf("%s\n", name);
@@ -69,5 +173,10 @@ int main(void) {
     run("dense",     bench_dense);
     run("dense_rev", bench_dense_rev);
     run("sparse",    bench_sparse);
+    run("iter1",     bench_iter_direct);
+    run("join1",     bench_join_single);
+    run("join_eq",   bench_join_equal);
+    run("join_sl",   bench_join_small_lead);
+    run("join_ll",   bench_join_large_lead);
     return 0;
 }


### PR DESCRIPTION
## Summary
- benchmark direct iteration versus table_join on 1 table
- benchmark table_join on 2 tables for equal-sized, small-lead, and large-lead cases

## Testing
- `ninja -f build.ninja`
- `./out/test > /tmp/test.log`
- `./out/bench > /tmp/bench.log`

------
https://chatgpt.com/codex/tasks/task_e_686bb325cbfc83268f8d736286947267