### PR TITLE
Add table_scatter()

### DIFF
--- a/ecs.c
+++ b/ecs.c
@@ -90,3 +90,12 @@ _Bool table_join(struct table const *table[], int tables, int *key, void *vals) 
     }
     return 0;
 }
+
+void table_scatter(struct table *table[], int tables, int key, void const *vals) {
+    char const *src = vals;
+    for (int i = 0; i < tables; i++) {
+        void *dst = table_get(table[i], key);
+        copy(dst, src, table[i]->size);
+        src += table[i]->size;
+    }
+}

--- a/ecs.h
+++ b/ecs.h
@@ -15,3 +15,4 @@ void  table_drop(struct table *table);
 
 void* table_get (struct table const *table, int key);
 _Bool table_join(struct table const *table[], int tables, int *key, void *vals);
+void  table_scatter(struct table *table[], int tables, int key, void const *vals);

--- a/test.c
+++ b/test.c
@@ -172,6 +172,38 @@ static void test_overwrite(void) {
     table_drop(&tag);
 }
 
+static void test_scatter(void) {
+    struct table ints   = {.size = sizeof(int)};
+    struct table floats = {.size = sizeof(float)};
+
+    for (int i = 0; i < 3; i++) {
+        float f = (float)i;
+        table_set(&ints, i, &i);
+        table_set(&floats, i, &f);
+    }
+
+    struct table const *rtable[] = {&ints,&floats};
+    struct table       *wtable[] = {&ints,&floats};
+
+    int key = ~0;
+    struct { int i; float f; } vals;
+    while (table_join(rtable, len(rtable), &key, &vals)) {
+        vals.i *= 2;
+        vals.f *= 3.0f;
+        table_scatter(wtable, len(wtable), key, &vals);
+    }
+
+    for (int i = 0; i < 3; i++) {
+        int   *ip = table_get(&ints, i);
+        float *fp = table_get(&floats, i);
+        expect(*ip == i*2);
+        expect((int)*fp == i*3);
+    }
+
+    table_drop(&ints);
+    table_drop(&floats);
+}
+
 int main(void) {
     test_point_table();
     test_tag_table();
@@ -179,5 +211,6 @@ int main(void) {
     test_join_single();
     test_join_empty();
     test_overwrite();
+    test_scatter();
     return 0;
 }


### PR DESCRIPTION
## Summary
- add `table_scatter()` for writing back rows after `table_join()`
- test roundtripping with `table_scatter()`
- drop the unnecessary `dst` null check

## Testing
- `ninja -f build.ninja out/test.ok`

------
https://chatgpt.com/codex/tasks/task_e_686bf418ee1c8326bbc1d6ca1b811ef9