### PR TITLE
Rename tests and add coverage reporting

### DIFF
--- a/build.ninja
+++ b/build.ninja
@@ -20,11 +20,20 @@ rule link
 rule run
     command = LLVM_PROFILE_FILE=$in.profraw ./$in > $out
 
+rule mergecov
+    command = llvm-profdata merge -sparse $in -o $out
+
+rule reportcov
+    command = llvm-cov report out/test out/systems_test -instr-profile=$in > $out
+
+rule showcov
+    command = llvm-cov show out/test out/systems_test -instr-profile=$in > $out
+
 build out/bench.o: compile bench.c
 build out/opt.o:   compile ecs.c
 build out/dbg.o:   compile ecs.c
     cc = $cc $dbg
-build out/test.o:  compile test.c
+build out/test.o:  compile ecs_test.c
     cc = $cc $dbg
 build out/systems_test.o: compile systems_test.c
     cc = $cc $dbg
@@ -43,3 +52,7 @@ build out/aihack: link out/aihack.o out/systems.o out/dbg.o
 
 build out/test.ok: run out/test
 build out/systems_test.ok: run out/systems_test
+
+build out/coverage.profdata: mergecov out/test.profraw out/systems_test.profraw || out/test.ok out/systems_test.ok
+build out/coverage.report: reportcov out/coverage.profdata
+build out/coverage.detail: showcov out/coverage.profdata

--- a/ecs_test.c
+++ b/ecs_test.c
@@ -1,11 +1,7 @@
 #include "ecs.h"
 #include <stdio.h>
 #include <stdlib.h>
-
-static inline void expect_(_Bool x, const char *expr, const char *file, int line) {
-    if (!x) { fprintf(stderr, "%s:%d expect(%s)\n", file, line, expr);  __builtin_debugtrap(); }
-}
-#define expect(x) expect_(x, #x, __FILE__, __LINE__)
+#include "test.h"
 
 static void test_points(void) {
     struct point { float x,y; };

--- a/systems_test.c
+++ b/systems_test.c
@@ -2,11 +2,7 @@
 #include "systems.h"
 #include <stdlib.h>
 #include <stdio.h>
-
-static inline void expect_(_Bool x, const char *expr, const char *file, int line) {
-    if (!x) { fprintf(stderr, "%s:%d expect(%s)\n", file, line, expr); __builtin_debugtrap(); }
-}
-#define expect(x) expect_(x, #x, __FILE__, __LINE__)
+#include "test.h"
 
 static void test_draw(void) {
     enum { W = 3, H = 2 };

--- a/test.h
+++ b/test.h
@@ -1,0 +1,11 @@
+#ifndef TEST_H
+#define TEST_H
+#include <stdio.h>
+
+static inline void expect_(_Bool x, char const *expr,
+                           char const *file, int line) {
+    if (!x) { fprintf(stderr, "%s:%d expect(%s)\n", file, line, expr); __builtin_debugtrap(); }
+}
+#define expect(x) expect_(x, #x, __FILE__, __LINE__)
+
+#endif // TEST_H


### PR DESCRIPTION
## Summary
- rename `test.c` to `ecs_test.c`
- share `expect()` in new `test.h`
- update build rules to merge coverage and run `llvm-cov`

## Testing
- `ninja -v out/test.ok out/systems_test.ok`
- `ninja -v out/coverage.report out/coverage.detail`

------
https://chatgpt.com/codex/tasks/task_e_6872c81267cc8326a97fbbb62774deab