### PR TITLE
Restore benchmark tool

### DIFF
--- a/bench.c
+++ b/bench.c
@@ -1,0 +1,120 @@
+#include "ecs.h"
+#include <math.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <time.h>
+
+static unsigned rng(unsigned seed) {
+    __builtin_mul_overflow(seed, 1103515245u, &seed);
+    __builtin_add_overflow(seed,      12345u, &seed);
+    return seed;
+}
+
+static double now(void) {
+    struct timespec ts;
+    clock_gettime(CLOCK_MONOTONIC, &ts);
+    return (double)ts.tv_sec + (double)ts.tv_nsec / 1e9;
+}
+
+static void free_ptr(void *p) {
+    free(*(void**)p);
+}
+
+static void free_sparse_set(void *p) {
+    sparse_set *meta = p;
+    free(meta->id);
+    free(meta->ix);
+}
+
+static double bench_ascending(int n) {
+    __attribute__((cleanup(free_ptr)))        int       *vals = NULL;
+    __attribute__((cleanup(free_sparse_set))) sparse_set meta = {0};
+
+    double const start = now();
+    for (int i = 0; i < n; i++) {
+        vals = component_attach(vals, sizeof *vals, &meta, i);
+    }
+    double const elapsed = now() - start;
+    return elapsed;
+}
+
+static double bench_descending(int n) {
+    __attribute__((cleanup(free_ptr)))        int       *vals = NULL;
+    __attribute__((cleanup(free_sparse_set))) sparse_set meta = {0};
+
+    double const start = now();
+    for (int i = n-1; i >= 0; i--) {
+        vals = component_attach(vals, sizeof *vals, &meta, i);
+    }
+    double const elapsed = now() - start;
+    return elapsed;
+}
+
+static double bench_sparse(int n) {
+    __attribute__((cleanup(free_ptr)))        int       *vals = NULL;
+    __attribute__((cleanup(free_sparse_set))) sparse_set meta = {0};
+
+    double const start = now();
+    for (int i = 0; i < n; i++) {
+        int const id = i * 10;
+        vals = component_attach(vals, sizeof *vals, &meta, id);
+    }
+    double const elapsed = now() - start;
+    return elapsed;
+}
+
+static double bench_random(int n) {
+    __attribute__((cleanup(free_ptr)))        int       *vals = NULL;
+    __attribute__((cleanup(free_sparse_set))) sparse_set meta = {0};
+    unsigned seed = 1;
+
+    double const start = now();
+    for (int i = 0; i < n; i++) {
+        seed = rng(seed);
+        int const id = (int)(seed % (unsigned)(10*n));
+        vals = component_attach(vals, sizeof *vals, &meta, id);
+    }
+    double const elapsed = now() - start;
+    return elapsed;
+}
+
+static void run(char const *pattern,
+                char const *name,
+                double (*fn)(int)) {
+    if (strstr(name, pattern)) {
+        printf("%s\n", name);
+
+        int lgN = 10;
+        double min,max;
+        do {
+            int const N = 1<<lgN;
+            min = +1/0.0;
+            max = -1/0.0;
+            for (double const start = now(); now() - start < 1/16.0;) {
+                double const t = fn(N);
+                if (min > t) { min = t; }
+                if (max < t) { max = t; }
+            }
+            printf("%s%2d %4.1f–%4.1f%s ", lgN==10 ? "N=2^" : "    ", lgN,
+                                           min*1e9/N, max*1e9/N,
+                                           lgN==10 ? "ns" : "  ");
+            long i = 0;
+            for (; i < lrint(min*1e9/N) && i < 80; i++) { printf("#"); }
+            for (; i < lrint(max*1e9/N) && i < 80; i++) { printf("."); }
+            printf("\n");
+            lgN++;
+        } while (min < max);
+        printf("\n");
+    }
+}
+
+int main(int argc, char const* argv[]) {
+    char const *pattern = argc > 1 ? argv[1] : "";
+    run(pattern, "ascending",  bench_ascending);
+    run(pattern, "descending", bench_descending);
+    run(pattern, "sparse",     bench_sparse);
+    run(pattern, "random",     bench_random);
+    return 0;
+}
+

--- a/build.ninja
+++ b/build.ninja
@@ -25,5 +25,8 @@ build out/ecs_test.o:  compile  ecs_test.c
 build out/ecs_test:    link out/ecs_test.o out/ecs.o
 build out/ecs_test.ok: run  out/ecs_test
 
+build out/bench.o: compile bench.c
+build out/bench:   link out/bench.o out/ecs.o
+
 build out/aihack.o: compile  aihack.c
 build out/aihack:   link out/aihack.o out/ecs.o


### PR DESCRIPTION
## Summary
- add benchmark tool measuring attach patterns (ascending, descending, sparse and random)
- build bench in `build.ninja`

## Testing
- `ninja -v out/ecs_test.ok`
- `ninja -v out/bench`
- `./out/bench > /tmp/bench_run.log`

------
https://chatgpt.com/codex/tasks/task_e_68817f7d620c8326afbc52666a788b51