### PR TITLE
Embed component metadata

### DIFF
--- a/aihack.c
+++ b/aihack.c
@@ -11,26 +11,24 @@ static int alloc_id(void) {
 }
 
 static struct pos {int x,y;} *pos;
-static sparse_set             pos_meta;
 
 struct stats {
     int hp, ac, atk, dmg;
 };
 static struct stats *stats;
-static sparse_set    stats_meta;
 
 static char      *glyph;
-static sparse_set glyph_meta;
 
 enum disposition { LEADER, PARTY, FRIENDLY, NEUTRAL, HOSTILE, MADDENED };
 static enum disposition *disp;
-static sparse_set        disp_meta;
 
-#define get(id, c)    component_lookup(c, sizeof *c, &c##_meta, id)
-#define set(id, c) (c=component_attach(c, sizeof *c, &c##_meta, id))[c##_meta.ix[id]]
-#define del(id, c)    component_detach(c, sizeof *c, &c##_meta, id)
+static sparse_set* meta_of(void *data) { return (sparse_set*)data - 1; }
 
-#define scan(c, p,id) c; for (int id=~0; p != c+c##_meta.n && (id=c##_meta.id[p-c]); p++)
+#define get(id, c)    component_lookup(c, sizeof *c, id)
+#define set(id, c) (c=component_attach(c, sizeof *c, id))[meta_of(c)->ix[id]]
+#define del(id, c)    component_detach(c, sizeof *c, id)
+
+#define scan(c,p,id) c; for (int id=~0; (c) && (p)!= (c)+meta_of(c)->n && (id=meta_of(c)->id[(p)-(c)],1); (p)++)
 
 static int entity_at(int x, int y) {
     struct pos const *p = scan(pos, p,id) {

--- a/bench.c
+++ b/bench.c
@@ -17,59 +17,49 @@ static double now(void) {
     return (double)ts.tv_sec + (double)ts.tv_nsec / 1e9;
 }
 
-static void free_ptr(void *p) {
-    free(*(void**)p);
-}
-
-static void free_sparse_set(void *p) {
-    sparse_set *meta = p;
-    free(meta->id);
-    free(meta->ix);
+static void free_component(void *p) {
+    component_free(*(void**)p);
 }
 
 static double bench_ascending(int n) {
-    __attribute__((cleanup(free_ptr)))        int       *vals = NULL;
-    __attribute__((cleanup(free_sparse_set))) sparse_set meta = {0};
+    __attribute__((cleanup(free_component))) int *vals = NULL;
 
     double const start = now();
     for (int i = 0; i < n; i++) {
-        vals = component_attach(vals, sizeof *vals, &meta, i);
+        vals = component_attach(vals, sizeof *vals, i);
     }
     return now() - start;
 }
 
 static double bench_descending(int n) {
-    __attribute__((cleanup(free_ptr)))        int       *vals = NULL;
-    __attribute__((cleanup(free_sparse_set))) sparse_set meta = {0};
+    __attribute__((cleanup(free_component))) int *vals = NULL;
 
     double const start = now();
     for (int i = n-1; i >= 0; i--) {
-        vals = component_attach(vals, sizeof *vals, &meta, i);
+        vals = component_attach(vals, sizeof *vals, i);
     }
     return now() - start;
 }
 
 static double bench_sparse(int n) {
-    __attribute__((cleanup(free_ptr)))        int       *vals = NULL;
-    __attribute__((cleanup(free_sparse_set))) sparse_set meta = {0};
+    __attribute__((cleanup(free_component))) int *vals = NULL;
 
     double const start = now();
     for (int i = 0; i < n; i++) {
-        vals = component_attach(vals, sizeof *vals, &meta, i*10);
+        vals = component_attach(vals, sizeof *vals, i*10);
     }
     return now() - start;
 }
 
 static double bench_random(int n) {
-    __attribute__((cleanup(free_ptr)))        int       *vals = NULL;
-    __attribute__((cleanup(free_sparse_set))) sparse_set meta = {0};
+    __attribute__((cleanup(free_component))) int *vals = NULL;
     unsigned seed = 1;
 
     double const start = now();
     for (int i = 0; i < n; i++) {
         seed = rng(seed);
         int const id = (int)(seed % (unsigned)n);
-        vals = component_attach(vals, sizeof *vals, &meta, id);
+        vals = component_attach(vals, sizeof *vals, id);
     }
     return now() - start;
 }

--- a/ecs.c
+++ b/ecs.c
@@ -10,18 +10,32 @@ static _Bool is_pow2_or_zero(int x) {
     return (x & (x-1)) == 0;
 }
 
-void* component_attach(void *data, size_t size, sparse_set *meta, int id) {
+static sparse_set* meta_of(void *data) {
+    return (sparse_set*)data - 1;
+}
+
+void* component_attach(void *data, size_t size, int id) {
+    sparse_set *meta;
+    if (!data) {
+        meta = calloc(1, sizeof *meta);
+        data = meta + 1;
+    } else {
+        meta = meta_of(data);
+    }
+
     if (id >= meta->cap) {
         int const grown = max(id+1, 2*meta->cap);
         meta->ix = realloc(meta->ix, (size_t)grown * sizeof *meta->ix);
-        memset(meta->ix + meta->cap, ~0, (size_t)(grown - meta->cap) * sizeof *meta->ix);
+        memset(meta->ix + meta->cap, ~0,
+               (size_t)(grown - meta->cap) * sizeof *meta->ix);
         meta->cap = grown;
     }
 
     if (meta->ix[id] < 0) {
         if (is_pow2_or_zero(meta->n)) {
             int const grown = meta->n ? 2*meta->n : 1;
-            data     = realloc(data    , (size_t)grown * size            );
+            meta = realloc(meta, sizeof *meta + (size_t)grown * size);
+            data = (char*)meta + sizeof *meta;
             meta->id = realloc(meta->id, (size_t)grown * sizeof *meta->id);
         }
         int const ix = meta->n++;
@@ -32,13 +46,17 @@ void* component_attach(void *data, size_t size, sparse_set *meta, int id) {
     return data;
 }
 
-void component_detach(void *data, size_t size, sparse_set *meta, int id) {
+void component_detach(void *data, size_t size, int id) {
+    if (!data) {
+        return;
+    }
+    sparse_set *meta = meta_of(data);
     if (id < meta->cap) {
         int const ix = meta->ix[id];
         if (ix >= 0) {
             int const last = --meta->n;
-            memmove((char      *)data + (size_t)ix   * size,
-                    (char const*)data + (size_t)last * size, size);
+            memmove((char*)data + (size_t)ix   * size,
+                    (char*)data + (size_t)last * size, size);
             int const last_id = meta->id[last];
             meta->id[ix] = last_id;
             meta->ix[last_id] = ix;
@@ -47,7 +65,11 @@ void component_detach(void *data, size_t size, sparse_set *meta, int id) {
     }
 }
 
-void* component_lookup(void *data, size_t size, sparse_set const *meta, int id) {
+void* component_lookup(void *data, size_t size, int id) {
+    if (!data) {
+        return NULL;
+    }
+    sparse_set *meta = meta_of(data);
     if (id < meta->cap) {
         int const ix = meta->ix[id];
         if (ix >= 0) {
@@ -55,4 +77,13 @@ void* component_lookup(void *data, size_t size, sparse_set const *meta, int id) 
         }
     }
     return NULL;
+}
+
+void component_free(void *data) {
+    if (data) {
+        sparse_set *meta = meta_of(data);
+        free(meta->id);
+        free(meta->ix);
+        free(meta);
+    }
 }

--- a/ecs.h
+++ b/ecs.h
@@ -6,6 +6,7 @@ typedef struct {
     int   n,cap;
 } sparse_set;
 
-void* component_attach(void*, size_t, sparse_set      *, int id);
-void  component_detach(void*, size_t, sparse_set      *, int id);
-void* component_lookup(void*, size_t, sparse_set const*, int id);
+void* component_attach(void*, size_t, int id);
+void  component_detach(void*, size_t, int id);
+void* component_lookup(void*, size_t, int id);
+void  component_free(void*);

--- a/ecs_test.c
+++ b/ecs_test.c
@@ -2,131 +2,140 @@
 #include "test.h"
 #include <stdlib.h>
 
-static void free_ptr(void *p) {
-    free(*(void**)p);
+static void free_component(void *p) {
+    component_free(*(void**)p);
 }
 
-static void free_sparse_set(void *p) {
-    sparse_set *meta = p;
-    free(meta->id);
-    free(meta->ix);
+static sparse_set* meta_of(void *data) {
+    return (sparse_set*)data - 1;
 }
 
 static void test_attach_detach(void) {
-    __attribute__((cleanup(free_ptr)))        int       *vals = NULL;
-    __attribute__((cleanup(free_sparse_set))) sparse_set meta = {0};
+    __attribute__((cleanup(free_component))) int *vals = NULL;
 
     // Basic ID attach.
-    vals = component_attach(vals, sizeof *vals, &meta, 1);
-    expect(meta.n   == 1);
-    expect(meta.cap == 2);
-    expect(meta.ix[1] == 0);
-    expect(meta.id[0] == 1);
-    vals[meta.ix[1]] = 11;
+    vals = component_attach(vals, sizeof *vals, 1);
+    sparse_set *meta = meta_of(vals);
+    expect(meta->n   == 1);
+    expect(meta->cap == 2);
+    expect(meta->ix[1] == 0);
+    expect(meta->id[0] == 1);
+    vals[meta->ix[1]] = 11;
 
     // Re-attaching the same ID does nothing.
     int* const prev = vals;
-    vals = component_attach(vals, sizeof *vals, &meta, 1);
+    vals = component_attach(vals, sizeof *vals, 1);
+    meta = meta_of(vals);
     expect(vals == prev);
-    expect(meta.n == 1);
+    expect(meta->n == 1);
 
     // Attach a lower ID, no need to resize ix, but will resize id,vals.
-    vals = component_attach(vals, sizeof *vals, &meta, 0);
+    vals = component_attach(vals, sizeof *vals, 0);
+    meta = meta_of(vals);
     expect(vals != prev);
-    expect(meta.n   == 2);
-    expect(meta.cap == 2);
-    expect(meta.ix[0] == 1);
-    expect(meta.id[1] == 0);
-    vals[meta.ix[0]] = 22;
+    expect(meta->n   == 2);
+    expect(meta->cap == 2);
+    expect(meta->ix[0] == 1);
+    expect(meta->id[1] == 0);
+    vals[meta->ix[0]] = 22;
 
     // Attach a higher ID, everything grows.
-    vals = component_attach(vals, sizeof *vals, &meta, 5);
-    expect(meta.n   == 3);
-    expect(meta.cap == 6);
-    expect(meta.ix[5] == 2);
-    expect(meta.id[2] == 5);
-    vals[meta.ix[5]] = 55;
+    vals = component_attach(vals, sizeof *vals, 5);
+    meta = meta_of(vals);
+    expect(meta->n   == 3);
+    expect(meta->cap == 6);
+    expect(meta->ix[5] == 2);
+    expect(meta->id[2] == 5);
+    vals[meta->ix[5]] = 55;
 
     // Detach an unattached ID does nothing.
-    component_detach(vals, sizeof *vals, &meta, 3);
-    expect(meta.n == 3);
+    component_detach(vals, sizeof *vals, 3);
+    meta = meta_of(vals);
+    expect(meta->n == 3);
 
     // Detach an attached ID, swapping the last ID into its place.
-    expect(meta.ix[0] == 1);
-    component_detach(vals, sizeof *vals, &meta, 0);
-    expect(meta.n == 2);
-    expect(meta.ix[0] == ~0);
-    expect(meta.ix[5] == 1);
-    expect(meta.id[1] == 5);
+    expect(meta->ix[0] == 1);
+    component_detach(vals, sizeof *vals, 0);
+    meta = meta_of(vals);
+    expect(meta->n == 2);
+    expect(meta->ix[0] == ~0);
+    expect(meta->ix[5] == 1);
+    expect(meta->id[1] == 5);
     expect(vals[1] == 55);
 
     // Keep detatching, another swap.
-    component_detach(vals, sizeof *vals, &meta, 1);
-    expect(meta.n == 1);
-    expect(meta.ix[1] == ~0);
-    expect(meta.id[0] == 5);
-    expect(meta.ix[5] == 0);
+    component_detach(vals, sizeof *vals, 1);
+    meta = meta_of(vals);
+    expect(meta->n == 1);
+    expect(meta->ix[1] == ~0);
+    expect(meta->id[0] == 5);
+    expect(meta->ix[5] == 0);
     expect(vals[0] == 55);
 
     // Detach the last ID.
-    component_detach(vals, sizeof *vals, &meta, 5);
-    expect(meta.n == 0);
-    expect(meta.ix[5] == ~0);
+    component_detach(vals, sizeof *vals, 5);
+    meta = meta_of(vals);
+    expect(meta->n == 0);
+    expect(meta->ix[5] == ~0);
 }
 
 static void test_high_id(void) {
-    __attribute__((cleanup(free_ptr)))        int       *vals = NULL;
-    __attribute__((cleanup(free_sparse_set))) sparse_set meta = {0};
+    __attribute__((cleanup(free_component))) int *vals = NULL;
 
-    vals = component_attach(vals, sizeof *vals, &meta, 7);
-    expect(meta.n   == 1);
-    expect(meta.cap == 8);
-    expect(meta.ix[7] == 0);
-    expect(meta.id[0] == 7);
+    vals = component_attach(vals, sizeof *vals, 7);
+    sparse_set *meta = meta_of(vals);
+    expect(meta->n   == 1);
+    expect(meta->cap == 8);
+    expect(meta->ix[7] == 0);
+    expect(meta->id[0] == 7);
 
-    component_detach(vals, sizeof *vals, &meta, 7);
-    expect(meta.n == 0);
+    component_detach(vals, sizeof *vals, 7);
+    meta = meta_of(vals);
+    expect(meta->n == 0);
 }
 
 static void test_detach_invalid(void) {
-    __attribute__((cleanup(free_ptr)))        int       *vals = NULL;
-    __attribute__((cleanup(free_sparse_set))) sparse_set meta = {0};
+    __attribute__((cleanup(free_component))) int *vals = NULL;
 
-    vals = component_attach(vals, sizeof *vals, &meta, 1);
-    expect(meta.n == 1);
-    component_detach(vals, sizeof *vals, &meta, 3);
-    expect(meta.n == 1);
+    vals = component_attach(vals, sizeof *vals, 1);
+    sparse_set *meta = meta_of(vals);
+    expect(meta->n == 1);
+    component_detach(vals, sizeof *vals, 3);
+    meta = meta_of(vals);
+    expect(meta->n == 1);
 
-    component_detach(vals, sizeof *vals, &meta, 1);
-    expect(meta.n == 0);
-    component_detach(vals, sizeof *vals, &meta, 1);
-    expect(meta.n == 0);
+    component_detach(vals, sizeof *vals, 1);
+    meta = meta_of(vals);
+    expect(meta->n == 0);
+    component_detach(vals, sizeof *vals, 1);
+    meta = meta_of(vals);
+    expect(meta->n == 0);
 }
 
 static void test_lookup(void) {
-    __attribute__((cleanup(free_ptr)))        int       *vals = NULL;
-    __attribute__((cleanup(free_sparse_set))) sparse_set meta = {0};
+    __attribute__((cleanup(free_component))) int *vals = NULL;
 
-    expect(component_lookup(vals, sizeof *vals, &meta, 1) == NULL);
+    expect(component_lookup(vals, sizeof *vals, 1) == NULL);
 
-    vals = component_attach(vals, sizeof *vals, &meta, 2);
-    vals = component_attach(vals, sizeof *vals, &meta, 5);
-    vals[meta.ix[2]] = 22;
-    vals[meta.ix[5]] = 55;
+    vals = component_attach(vals, sizeof *vals, 2);
+    vals = component_attach(vals, sizeof *vals, 5);
+    sparse_set *meta = meta_of(vals);
+    vals[meta->ix[2]] = 22;
+    vals[meta->ix[5]] = 55;
 
-    expect(component_lookup(vals, sizeof *vals, &meta, 2) == vals + meta.ix[2]);
-    expect(*(int*)component_lookup(vals, sizeof *vals, &meta, 2) == 22);
-    expect(component_lookup(vals, sizeof *vals, &meta, 5) == vals + meta.ix[5]);
-    expect(*(int*)component_lookup(vals, sizeof *vals, &meta, 5) == 55);
+    expect(component_lookup(vals, sizeof *vals, 2) == vals + meta->ix[2]);
+    expect(*(int*)component_lookup(vals, sizeof *vals, 2) == 22);
+    expect(component_lookup(vals, sizeof *vals, 5) == vals + meta->ix[5]);
+    expect(*(int*)component_lookup(vals, sizeof *vals, 5) == 55);
 
-    expect(component_lookup(vals, sizeof *vals, &meta, 3) == NULL);
+    expect(component_lookup(vals, sizeof *vals, 3) == NULL);
 
-    component_detach(vals, sizeof *vals, &meta, 2);
-    expect(component_lookup(vals, sizeof *vals, &meta, 2) == NULL);
-    expect(*(int*)component_lookup(vals, sizeof *vals, &meta, 5) == 55);
+    component_detach(vals, sizeof *vals, 2);
+    expect(component_lookup(vals, sizeof *vals, 2) == NULL);
+    expect(*(int*)component_lookup(vals, sizeof *vals, 5) == 55);
 
-    component_detach(vals, sizeof *vals, &meta, 5);
-    expect(component_lookup(vals, sizeof *vals, &meta, 5) == NULL);
+    component_detach(vals, sizeof *vals, 5);
+    expect(component_lookup(vals, sizeof *vals, 5) == NULL);
 }
 
 int main(void) {


### PR DESCRIPTION
## Summary
- shift sparse set metadata directly before component data
- update component API to infer metadata from the pointer
- adjust tests and example code for new API

## Testing
- `ninja -f build.ninja out/ecs_test.ok`

------
https://chatgpt.com/codex/tasks/task_e_6889144a88dc8326b7edd1a1f77ad3ca