### PR TITLE
Fix sequencing bug in set() macro

### DIFF
--- a/aihack.c
+++ b/aihack.c
@@ -27,7 +27,7 @@ static enum disposition *disp;
 static sparse_set        disp_meta;
 
 #define get(id, c)    component_lookup(c, sizeof *c, &c##_meta, id)
-#define set(id, c) (c=component_attach(c, sizeof *c, &c##_meta, id))[c##_meta.ix[id]]
+#define set(id, c) (*(c=component_attach(c, sizeof *c, &c##_meta, id), c+c##_meta.ix[id]))
 #define del(id, c)    component_detach(c, sizeof *c, &c##_meta, id)
 
 #define scan(c, p,id) c; for (int id=~0; p != c+c##_meta.n && (id=c##_meta.id[p-c]); p++)


### PR DESCRIPTION
## Summary
- ensure `component_attach` completes before reading the new index

## Testing
- `ninja -v out/aihack`
- `ninja -v out/ecs_test.ok`

------
https://chatgpt.com/codex/tasks/task_e_6889447b4bf083268b5c6b5130e08de0