### PR TITLE
Add name component and corpse recycling

### DIFF
--- a/aihack.c
+++ b/aihack.c
@@ -196,15 +196,18 @@ static void combat_system(int event) {
                     if (roll == 20 || roll + as->atk >= ds->ac) {
                         ds->hp -= as->dmg;
                         if (ds->hp <= 0) {
-                            struct pos *dp = get(e->defender, pos);
+                            struct pos       *dp = get(e->defender, pos);
+                            struct pos        p;
+                            char const      **dn = get(e->defender, name);
+                            char const       *n = dn ? *dn : NULL;
                             int const corpse = next_id++;
                             if (dp) {
-                                set(corpse, pos) = *dp;
+                                p = *dp;
+                                set(corpse, pos) = p;
                                 del(e->defender, pos);
                             }
                             set(corpse, glyph) = 'x';
-                            char const **dn = get(e->defender, name);
-                            if (dn) { set(corpse, name) = *dn; }
+                            if (n) { set(corpse, name) = n; }
                             del(e->defender, glyph);
                             del(e->defender, stats);
                             del(e->defender, disp);


### PR DESCRIPTION
## Summary
- add a `name` component
- show attack messages with attacker and defender names
- spawn a new corpse entity instead of renaming the defender
- recycle dead entities at the end of the frame

## Testing
- `ninja -v out/aihack`
- `ninja -v out/ecs_test.ok`

------
https://chatgpt.com/codex/tasks/task_e_688d308ecbac83269532eb69240426d5