### PR TITLE
Track components and drop entities

### DIFF
--- a/bench.c
+++ b/bench.c
@@ -18,10 +18,7 @@ static double now(void) {
 }
 
 static void free_component(void *p) {
-    struct component *c = p;
-    free(c->data);
-    free(c->id);
-    free(c->ix);
+    component_free_((struct component*)p);
 }
 
 static double bench_ascending(int n) {

--- a/ecs.h
+++ b/ecs.h
@@ -4,17 +4,23 @@
 struct component {
     void *data;
     int  *id,*ix;
+    struct component *next;
+    size_t size;
     int   n,cap;
 };
 void* component_attach_(struct component      *, size_t, int id);
 void  component_detach_(struct component      *, size_t, int id);
-void* component_lookup_(struct component const*, size_t, int id);
+void* component_lookup_(struct component      *, size_t, int id);
+void  component_free_(struct component      *);
+void  entity_drop(int id);
 
 #define component(T) \
-    union { struct {T *data; int *id,*ix; int n,cap; }; struct component type_erased; }
+    union { struct {T *data; int *id,*ix; struct component *next; size_t size; \
+                    int n,cap;}; struct component type_erased; }
 
 #define component_attach(c,id) \
        (__typeof__((c)->data)) component_attach_(&(c)->type_erased, sizeof *(c)->data, id)
 #define component_detach(c,id) component_detach_(&(c)->type_erased, sizeof *(c)->data, id)
 #define component_lookup(c,id) \
        (__typeof__((c)->data)) component_lookup_(&(c)->type_erased, sizeof *(c)->data, id)
+#define component_free(c) component_free_(&(c)->type_erased)

--- a/ecs_test.c
+++ b/ecs_test.c
@@ -3,10 +3,7 @@
 #include <stdlib.h>
 
 static void free_component(void *p) {
-    struct component *c = p;
-    free(c->data);
-    free(c->id);
-    free(c->ix);
+    component_free_((struct component*)p);
 }
 
 static void test_attach_detach(void) {
@@ -122,10 +119,31 @@ static void test_lookup(void) {
     expect(component_lookup(&comp, 5) == NULL);
 }
 
+static void test_drop_entity(void) {
+    __attribute__((cleanup(free_component))) component(int) a = {0};
+    __attribute__((cleanup(free_component))) component(int) b = {0};
+
+    component_attach(&a, 1);
+    component_attach(&b, 1);
+    component_attach(&a, 2);
+    component_attach(&b, 2);
+
+    entity_drop(1);
+    expect(component_lookup(&a, 1) == NULL);
+    expect(component_lookup(&b, 1) == NULL);
+    expect(component_lookup(&a, 2));
+    expect(component_lookup(&b, 2));
+
+    entity_drop(2);
+    expect(component_lookup(&a, 2) == NULL);
+    expect(component_lookup(&b, 2) == NULL);
+}
+
 int main(void) {
     test_attach_detach();
     test_high_id();
     test_detach_invalid();
     test_lookup();
+    test_drop_entity();
     return 0;
 }


### PR DESCRIPTION
## Summary
- track all component instances via a global linked list
- add helper to free components and remove them from the registry
- implement `entity_drop` to remove an entity from every component
- cover entity dropping with a new test

## Testing
- `ninja -v out/ecs_test.ok`


------
https://chatgpt.com/codex/tasks/task_e_688e0137ecbc83269a013a18d6826ccc