### PR TITLE
Inline table component logic

### DIFF
--- a/build.ninja
+++ b/build.ninja
@@ -37,5 +37,5 @@ build out/aihack:   link out/aihack.o out/ecs.o
 
 build out/table.o:       compile  table.c
 build out/table_test.o:  compile  table_test.c
-build out/table_test:    link out/table_test.o out/table.o out/ecs.o
+build out/table_test:    link out/table_test.o out/table.o
 build out/table_test.ok: run  out/table_test

--- a/table.c
+++ b/table.c
@@ -1,8 +1,54 @@
 #include "table.h"
-#include "ecs.h"
 #include <limits.h>
 #include <stdlib.h>
 #include <string.h>
+
+struct component {
+    void *data;
+    int  *id,*ix;
+    int   n,cap;
+};
+
+static int max(int x, int y) {
+    return x > y ? x : y;
+}
+
+static _Bool is_pow2_or_zero(int x) {
+    return (x & (x-1)) == 0;
+}
+
+static void* component_attach_(struct component *c, size_t size, int id) {
+    if (id >= c->cap) {
+        int const grown = max(id+1, 2*c->cap);
+        c->ix = realloc(c->ix, (size_t)grown * sizeof *c->ix);
+        memset(c->ix + c->cap, ~0, (size_t)(grown - c->cap) * sizeof *c->ix);
+        c->cap = grown;
+    }
+
+    int ix = c->ix[id];
+    if (ix < 0) {
+        if (is_pow2_or_zero(c->n)) {
+            int const grown = c->n ? 2*c->n : 1;
+            c->data = realloc(c->data, (size_t)grown * size);
+            c->id   = realloc(c->id,   (size_t)grown * sizeof *c->id);
+        }
+        ix = c->n++;
+        c->id[ix] = id;
+        c->ix[id] = ix;
+    }
+
+    return (char*)c->data + (size_t)ix * size;
+}
+
+static void* component_lookup_(struct component const *c, size_t size, int id) {
+    if (id < c->cap) {
+        int const ix = c->ix[id];
+        if (ix >= 0) {
+            return (char*)c->data + (size_t)ix * size;
+        }
+    }
+    return NULL;
+}
 
 static void ensure(struct table *t) {
     if (!t->comp && t->columns) {

--- a/table.h
+++ b/table.h
@@ -2,6 +2,8 @@
 
 #include <stddef.h>
 
+struct component;
+
 struct table {
     size_t const     *column_size;
     int               columns;

--- a/table.h
+++ b/table.h
@@ -2,8 +2,6 @@
 
 #include <stddef.h>
 
-struct component;
-
 struct table {
     size_t const     *column_size;
     int               columns;


### PR DESCRIPTION
## Summary
- Inline `struct component` and related helpers into `table.c`
- Forward declare component in `table.h` and drop `ecs` header dependency
- Build table tests without linking against `ecs`

## Testing
- `ninja out/table_test.ok`
- `ninja out/ecs_test.ok`


------
https://chatgpt.com/codex/tasks/task_e_688fe94fd8108326b9abbe35c1a5e02c